### PR TITLE
fix - added labels to inner chart renderer

### DIFF
--- a/Source/Charts/Renderers/PieChartInnerPercentageCircleRenderer.swift
+++ b/Source/Charts/Renderers/PieChartInnerPercentageCircleRenderer.swift
@@ -26,6 +26,7 @@ open class PieChartInnerPercentageCircleRenderer : PieChartRenderer {
     
     
     open override func drawExtras(context: CGContext) {
+        super.drawExtras(context: context)
         drawCenterPieChart(context: context)
     }
 


### PR DESCRIPTION
added the inner text label to the PieChartInnerPercentageCircleRenderer