### PR TITLE
Fix : PieChart initialize override

### DIFF
--- a/Source/Charts/Charts/PieChartInnerPercentageView.swift
+++ b/Source/Charts/Charts/PieChartInnerPercentageView.swift
@@ -30,8 +30,8 @@ open class PieChartInnerPercentageView : PieChartView {
     {
         super.init(coder: aDecoder)
     }
-
-    override func initialize() {
+    
+    open override func initialize() {
         super.initialize()
         renderer = PieChartInnerPercentageCircleRenderer(self, _animator, _viewPortHandler)
         _xAxis = nil


### PR DESCRIPTION
Adding the ‘open’ access level to the initialize(). This is needed in order to implement the override from outside the module.